### PR TITLE
Cloning depracation issue

### DIFF
--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -74,6 +74,7 @@ module InstallMgrCookbook
             mode '0750'
             recursive true
             action :create
+            not_if { ::Dir.exist?(dir) }
           end
         end
 


### PR DESCRIPTION
[Description]
1. There can be a case where one of the required directories is also the
home directory of a user. In this case, a directory will get created
twice with the same parameters. Chef flags this as a cloning error. More
details at https://docs.chef.io/deprecations_resource_cloning.html